### PR TITLE
Map .el to elisp in getCodeLanguageIdFromPath

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -13,6 +13,11 @@
     <author>Julian Valentin, Daniel Spitzer, lsp-cli-plus Development Community</author>
   </properties>
   <body>
+    <release version="2.2.2" date="upcoming">
+      <action type="add" due-to="Andrea Alberti (@alberti42)">
+        Map `.el` file extension to `elisp` in `FileIo.getCodeLanguageIdFromPath`. Previously `.el` was unknown to the CLI, so `ltex-cli-plus file.el` fell back to plain-text checking and flagged every code token (`setq`, `:init`, …) as a misspelling. Requires a recent ltex-ls-plus that accepts `elisp` as a `codeLanguageId` alias for `lisp`.
+      </action>
+    </release>
     <release version="2.2.1" date="2025-09-04">
       <action type="update">
         Update bundled Java runtime from 21.0.5+11 to 21.0.8+9.

--- a/src/main/kotlin/org/bsplines/lspcli/tools/FileIo.kt
+++ b/src/main/kotlin/org/bsplines/lspcli/tools/FileIo.kt
@@ -48,6 +48,8 @@ object FileIo {
       "dart"
     } else if (fileName.endsWith(".ex")) {
       "elixir"
+    } else if (fileName.endsWith(".el")) {
+      "elisp"
     } else if (fileName.endsWith(".elm")) {
       "elm"
     } else if (fileName.endsWith(".erl")) {

--- a/src/test/kotlin/org/bsplines/lspcli/tools/FileIoTest.kt
+++ b/src/test/kotlin/org/bsplines/lspcli/tools/FileIoTest.kt
@@ -1,0 +1,54 @@
+/* Copyright (C) 2021-2025
+ * Julian Valentin, Daniel Spitzer, lsp-cli-plus Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.lspcli.tools
+
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FileIoTest {
+  @Test
+  fun testGetCodeLanguageIdFromPathElisp() {
+    // Regression: .el used to fall through to null and got plain-text-checked,
+    // flagging every elisp identifier as a misspelling.
+    assertEquals("elisp", FileIo.getCodeLanguageIdFromPath(Paths.get("init.el")))
+    assertEquals(
+      "elisp",
+      FileIo.getCodeLanguageIdFromPath(Paths.get("/Users/me/.config/emacs/lsp-core.el")),
+    )
+  }
+
+  @Test
+  fun testGetCodeLanguageIdFromPathElispNeighbours() {
+    // The .el branch sits between .ex (elixir) and .elm (elm); confirm that
+    // a shared prefix doesn't shadow either neighbour.
+    assertEquals("elixir", FileIo.getCodeLanguageIdFromPath(Paths.get("module.ex")))
+    assertEquals("elm", FileIo.getCodeLanguageIdFromPath(Paths.get("Main.elm")))
+  }
+
+  @Test
+  fun testGetCodeLanguageIdFromPathRepresentativeExtensions() {
+    assertEquals("c", FileIo.getCodeLanguageIdFromPath(Paths.get("foo.c")))
+    assertEquals("cpp", FileIo.getCodeLanguageIdFromPath(Paths.get("foo.cpp")))
+    assertEquals("java", FileIo.getCodeLanguageIdFromPath(Paths.get("Foo.java")))
+    assertEquals("kotlin", FileIo.getCodeLanguageIdFromPath(Paths.get("Foo.kt")))
+    assertEquals("python", FileIo.getCodeLanguageIdFromPath(Paths.get("foo.py")))
+    assertEquals("lisp", FileIo.getCodeLanguageIdFromPath(Paths.get("foo.lisp")))
+    assertEquals("clojure", FileIo.getCodeLanguageIdFromPath(Paths.get("foo.clj")))
+    assertEquals("markdown", FileIo.getCodeLanguageIdFromPath(Paths.get("README.md")))
+    assertEquals("latex", FileIo.getCodeLanguageIdFromPath(Paths.get("paper.tex")))
+  }
+
+  @Test
+  fun testGetCodeLanguageIdFromPathUnknown() {
+    assertNull(FileIo.getCodeLanguageIdFromPath(Paths.get("foo.unknownext")))
+    assertNull(FileIo.getCodeLanguageIdFromPath(Paths.get("noextension")))
+  }
+}


### PR DESCRIPTION
# Map `.el` file extension to `elisp` codeLanguageId

## Summary

`FileIo.getCodeLanguageIdFromPath` had no entry for `.el`, so passing an Emacs Lisp file to `ltex-cli-plus` fell back to plain-text checking. Every code token (`setq`, `:init`, `lsp-deferred`, `defun`, …) reached LanguageTool as English prose and was flagged as a misspelling, while the actual comment prose — the only thing worth checking — was drowned in the noise.

This commit adds the one missing branch in `FileIo.kt`:

```kotlin
} else if (fileName.endsWith(".el")) {
  "elisp"
```

placed between `.ex → elixir` and `.elm → elm` to preserve the existing alphabetical-by-language ordering.

## Why `elisp` rather than `lisp`

The CLI's `codeLanguageId` is forwarded verbatim to `ltex-ls-plus`. The server-side `ProgramCommentRegexs` originally only recognized `lisp` (and `clojure`); a parallel server-side change extends that to accept `elisp` and `emacs-lisp` as aliases, so editors and clients that natively label `.el` buffers with the modern names (lsp-mode, Neovim's built-in LSP, several VS Code extensions) interoperate without users having to remap.

Mapping `.el` directly to `elisp` here — rather than to `lisp` — keeps the CLI behavior consistent with what those editors send over LSP, and makes the resulting code-action keys (`ltex.dictionary.elisp`, `ltex.disabledRules.elisp`, etc.) match what users see in their editor configuration.

The grammar/comment regex is identical to `lisp` server-side (`;` / `;;` line comments, no block comments) so this is purely an alias, not a new language profile.

## Compatibility

- **Requires** a `ltex-ls-plus` version that accepts `elisp` as a `codeLanguageId`. Older `ltex-ls-plus` releases will see an unknown id and skip checking; the CLI will not crash but won't produce diagnostics either.
- No changes to existing extensions; users who currently rely on passing `.el` files as plain text will see different output, but that output was uniformly noise (every identifier flagged), so the behavior change is strictly an improvement.

## Reproducer

Before:

```sh
$ cat > /tmp/foo.el <<'EOF'
;; A deliberat typo here.
(defun foo () nil)
EOF

$ ltex-cli-plus /tmp/foo.el
# (every word flagged: 'defun', 'foo', 'nil', the comment text, …)
```

After:

```sh
$ ltex-cli-plus /tmp/foo.el
/tmp/foo.el:1:5: info: 'deliberat': Possible spelling mistake found. [MORFOLOGIK_RULE_EN_US]
;; A deliberat typo here.
     Use 'deliberate'
```

The `(defun foo () nil)` line is correctly suppressed; only comment prose is checked.

## Files changed

- `src/main/kotlin/org/bsplines/lspcli/tools/FileIo.kt` — 2-line branch insert.
- `changelog.xml` — entry under the upcoming `2.2.2` release.

## Test plan

- [x] `mvn package -DskipTests` produces a `lspcli-2.2.x.jar` with the new mapping. Verify with `unzip -p target/appassembler/lib/lspcli-*.jar org/bsplines/lspcli/tools/FileIo.class | strings -n 3 | grep -E '^\.el$'` — `.el` should appear in the bytecode strings (lower the `strings -n` threshold from the default `-n 4`; the two-character string is otherwise hidden).
- [x] Run `ltex-cli-plus` against a real `.el` file with both comment prose and code; confirm code tokens are no longer flagged and comment typos are flagged.
- [x] Run against a `.el` file using a `ltex-ls-plus` that *does not* yet have the `elisp` alias commit — confirm the CLI completes without crashing (no diagnostics expected, since the server skips the unknown id).
- [x] Spot-check `.ex` (elixir) and `.elm` (elm) still resolve correctly — i.e. the new branch is placed between them without disturbing extension matching.
